### PR TITLE
jsxgraph viewer and example

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,13 +3,8 @@
         thheller/shadow-cljs {:mvn/version "2.16.12"}
 
         ;; SICMUtils computer algebra system!
-        sicmutils/sicmutils
-        {:mvn/version "0.22.0"}
-        #_{:local/root "../sicmutils"}
-
-        io.github.nextjournal/clerk
-        {:mvn/version "0.10.560"}
-        #_{:local/root "../clerk"}
+        sicmutils/sicmutils {:mvn/version "0.22.0"}
+        io.github.nextjournal/clerk {:mvn/version "0.10.560"}
 
         ;; All of the following seem to be required if you want to run the
         ;; shadow build that compiles the viewers.
@@ -18,21 +13,7 @@
         reagent/reagent {:mvn/version "1.1.1"}
         io.github.babashka/sci.configs {:git/sha "fcd367c6a6115c5c4e41f3a08ee5a8d5b3387a18"}
         io.github.nextjournal/viewers {:git/sha "3284aae7379bde3fcf41d17c663bed421fb31d6d"}
-        metosin/reitit-frontend {:mvn/version "0.5.15"}
-
-        ;; io.github.nextjournal/viewers
-        ;; {:git/sha "3284aae7379bde3fcf41d17c663bed421fb31d6d"
-        ;;  :exclusions [io.github.nextjournal/markdown]}
-
-
-        ;; io.github.babashka/sci-configs
-        ;; {:git/sha "fcd367c6a6115c5c4e41f3a08ee5a8d5b3387a18"}
-
-        ;; ;; applied-science/js-interop {:mvn/version "0.3.3"}
-        ;; org.babashka/sci {:mvn/version "0.3.5"}
-        ;; metosin/reitit-frontend {:mvn/version "0.5.15"}
-        ;; reagent/reagent {:mvn/version "1.1.1"}
-        }
+        metosin/reitit-frontend {:mvn/version "0.5.15"}}
 
  :aliases
  {:nextjournal/clerk
@@ -40,4 +21,8 @@
    ;; notebooks to be built, accepts glob patterns. This doesn't quite work yet!
    :exec-args {:bundle? false :paths ["index.md"
                                       "src/demo.clj"
-                                      "src/functions.clj"]}}}}
+                                      "src/functions.clj"]}}
+  :local
+  {:replace-deps
+   {io.github.nextjournal/clerk {:local/root "../clerk"}
+    sicmutils/sicmutils {:local/root "../sicmutils"}}}}}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "emoji-regex": "^10.0.0",
     "fraction.js": "^4.0.12",
     "framer-motion": "^6.2.8",
-    "jsxgraph": "^1.4.5",
+    "jsxgraph": "^1.4.6",
     "katex": "^0.12.0",
     "lezer-clojure": "1.0.0-rc.2",
     "markdown-it": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,14 @@
     "@lezer/generator": "^1.0.0",
     "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0",
+    "canvas": "^2.10.1",
+    "complex.js": "^2.0.11",
     "d3-require": "^1.2.4",
+    "dat.gui": "^0.7.9",
     "emoji-regex": "^10.0.0",
+    "fraction.js": "^4.0.12",
     "framer-motion": "^6.2.8",
+    "jsxgraph": "^1.4.5",
     "katex": "^0.12.0",
     "lezer-clojure": "1.0.0-rc.2",
     "markdown-it": "^12.2.0",
@@ -25,21 +30,14 @@
     "markdown-it-sidenote": "gerwitz/markdown-it-sidenote#aa5de8ce3168b7d41cb33c3aed071a5f41ce0083",
     "markdown-it-texmath": "^0.9.1",
     "markdown-it-toc-done-right": "^4.2.0",
+    "mathbox": "^2.2.0",
+    "mathbox-react": "0.0.10",
+    "odex": "^2.0.4",
     "punycode": "2.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "w3c-keyname": "2.2.4",
-
-    "complex.js": "^2.0.11",
-    "fraction.js": "^4.0.12",
-    "odex": "^2.0.4",
-
-    "dat.gui": "^0.7.9",
-    "jsxgraph": "^1.4.5",
-
-    "mathbox": "^2.2.0",
-    "mathbox-react": "0.0.10",
-    "three": "^0.137.5"
+    "three": "^0.137.5",
+    "w3c-keyname": "2.2.4"
   },
   "engines": {
     "npm": "6.14.8"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "emoji-regex": "^10.0.0",
     "fraction.js": "^4.0.12",
     "framer-motion": "^6.2.8",
-    "jsxgraph": "^1.4.6",
+    "@mentatcollective/jsxgraph": "^1.5.0",
     "katex": "^0.12.0",
     "lezer-clojure": "1.0.0-rc.2",
     "markdown-it": "^12.2.0",

--- a/src/demo/jsxgraph.cljs
+++ b/src/demo/jsxgraph.cljs
@@ -1,5 +1,24 @@
 (ns demo.jsxgraph
   "Eventually this will contain wrapper forms for jsxgraph. For now ignore the
   reactish part and just blow away the full jsxgraph whenever the input
-  change."
+  change.
+
+  For any of this to work, you'll need to
+
+  ```
+  npm install canvas
+  ```
+
+  Add the [build](https://github.com/jsxgraph/jsxgraph/tree/master/build)
+  directory from the jsxgraph repo into `node_modules/jsxgraph` in your project.
+  shadow-cljs needs this and they seem to have left it out of the project.
+
+  See my issue here: https://github.com/jsxgraph/jsxgraph/pull/456, hopefully
+  neither of these will be necessary soon."
   (:require ["jsxgraph" :as jsx]))
+
+(defn create [id]
+  (js/console.log jsx)
+  (let [board (.initBoard jsx/JSXGraph id #js {:boundingbox #js [-5 5 5 -5]
+                                               :axis true})]
+    board))

--- a/src/demo/jsxgraph.cljs
+++ b/src/demo/jsxgraph.cljs
@@ -13,7 +13,7 @@
   https://github.com/sritchie/jsxgraph, on this branch:
   https://github.com/jsxgraph/jsxgraph/pull/463"
   ;; this is the generated bundle I have. I should really just go to relative paths...
-  (:require ["jsxgraph/bundle/jsxgraph" :default jsx]))
+  (:require ["jsxgraph" :default jsx]))
 
 (defn create
   "NICE!!! Basic example, but it works!!"
@@ -27,17 +27,13 @@
         b (.create board "slider" #js [#js [1 1] #js [5 1] #js [0 (* 2 Math/PI) 10]] #js {:name "end"})
         f #(Math/sin %)
         _plot (.create board "functiongraph" #js [f #(.Value a) #(.Value b)])
-        _os (.create board "riemannsum" #js [f
-                                             #(.Value s)
-                                             (fn [] "left")
-                                             #(.Value a)
-                                             #(.Value b)]
-                     #js {:fillColor "#ffff00" :fillOpacity 0.3})]
+        r (.create board "riemannsum" #js [f
+                                           #(.Value s)
+                                           (fn [] "left")
+                                           #(.Value a)
+                                           #(.Value b)]
+                   #js {:fillColor "#ffff00" :fillOpacity 0.3})]
     (.create board
              "text"
-             #js [-6 -3
-                  (fn [] (str "Sum="
-                             (-> jsx (.-Math) (.-Numerics)
-                                 (.riemannsum f (.Value s) "left" (.Value a) (.Value b))
-                                 (.toFixed 4))))])
+             #js [-6 -3 (fn [] (str "Sum=" (.toFixed jsx (.Value r) 4)))])
     board))

--- a/src/demo/jsxgraph.cljs
+++ b/src/demo/jsxgraph.cljs
@@ -13,7 +13,7 @@
   https://github.com/sritchie/jsxgraph, on this branch:
   https://github.com/jsxgraph/jsxgraph/pull/463"
   ;; this is the generated bundle I have. I should really just go to relative paths...
-  (:require ["jsxgraph" :default jsx]))
+  (:require ["@mentatcollective/jsxgraph" :default jsx]))
 
 (defn create
   "NICE!!! Basic example, but it works!!"

--- a/src/demo/jsxgraph.cljs
+++ b/src/demo/jsxgraph.cljs
@@ -9,16 +9,35 @@
   npm install canvas
   ```
 
-  Add the [build](https://github.com/jsxgraph/jsxgraph/tree/master/build)
-  directory from the jsxgraph repo into `node_modules/jsxgraph` in your project.
-  shadow-cljs needs this and they seem to have left it out of the project.
+  For this to work, you'll need to use my fork of JSXGraph:
+  https://github.com/sritchie/jsxgraph, on this branch:
+  https://github.com/jsxgraph/jsxgraph/pull/463"
+  ;; this is the generated bundle I have. I should really just go to relative paths...
+  (:require ["jsxgraph/bundle/jsxgraph" :default jsx]))
 
-  See my issue here: https://github.com/jsxgraph/jsxgraph/pull/456, hopefully
-  neither of these will be necessary soon."
-  (:require ["jsxgraph" :as jsx]))
-
-(defn create [id]
-  (js/console.log jsx)
-  (let [board (.initBoard jsx/JSXGraph id #js {:boundingbox #js [-5 5 5 -5]
-                                               :axis true})]
+(defn create
+  "NICE!!! Basic example, but it works!!"
+  [id]
+  (let [board (-> (.-JSXGraph jsx)
+                  (.initBoard id #js {:boundingbox #js [-8 4 8 -4]
+                                      :showCopyright false
+                                      :axis true}))
+        s (.create board "slider" #js [#js [1 3] #js [5 3] #js [1 10 50]] #js {:name "n" :snapWidth 1})
+        a (.create board "slider" #js [#js [1 2] #js [5 2] #js [-10 -3 0]] #js {:name "start"})
+        b (.create board "slider" #js [#js [1 1] #js [5 1] #js [0 (* 2 Math/PI) 10]] #js {:name "end"})
+        f #(Math/sin %)
+        _plot (.create board "functiongraph" #js [f #(.Value a) #(.Value b)])
+        _os (.create board "riemannsum" #js [f
+                                             #(.Value s)
+                                             (fn [] "left")
+                                             #(.Value a)
+                                             #(.Value b)]
+                     #js {:fillColor "#ffff00" :fillOpacity 0.3})]
+    (.create board
+             "text"
+             #js [-6 -3
+                  (fn [] (str "Sum="
+                             (-> jsx (.-Math) (.-Numerics)
+                                 (.riemannsum f (.Value s) "left" (.Value a) (.Value b))
+                                 (.toFixed 4))))])
     board))

--- a/src/demo/jsxgraph.cljs
+++ b/src/demo/jsxgraph.cljs
@@ -3,20 +3,15 @@
   reactish part and just blow away the full jsxgraph whenever the input
   change.
 
-  For any of this to work, you'll need to
-
-  ```
-  npm install canvas
-  ```
-
-  For this to work, you'll need to use my fork of JSXGraph:
-  https://github.com/sritchie/jsxgraph, on this branch:
-  https://github.com/jsxgraph/jsxgraph/pull/463"
-  ;; this is the generated bundle I have. I should really just go to relative paths...
+  This is currently using my fork of jsxgraph at
+  https://github.com/sritchie/jsxgraph and published to
+  https://www.npmjs.com/package/@mentatcollective/jsxgraph, but these changes
+  should appear upstream soon and we can back off to the official library."
   (:require ["@mentatcollective/jsxgraph" :default jsx]))
 
 (defn create
-  "NICE!!! Basic example, but it works!!"
+  "Creates an example jsxgraph instance with a plane, a sine wave and a Riemann
+  sum."
   [id]
   (let [board (-> (.-JSXGraph jsx)
                   (.initBoard id #js {:boundingbox #js [-8 4 8 -4]

--- a/src/demo/viewers.cljs
+++ b/src/demo/viewers.cljs
@@ -1,6 +1,6 @@
 (ns demo.viewers
   (:require ["dat.gui" :as dg]
-            ;; [demo.jsxgraph]
+            [demo.jsxgraph]
             [demo.mathbox]
             [nextjournal.clerk.sci-viewer :as sv]
             ["mathbox-react" :as MB]
@@ -29,9 +29,8 @@
         {"mathbox-react" mbr-ns
          'demo.mathbox (sci/copy-ns demo.mathbox (sci/create-ns 'demo.mathbox))
 
-         ;; 'demo.jsxgraph
-         ;; (sci/copy-ns demo.jsxgraph (sci/create-ns 'demo.jsxgraph))
-         }
+         'demo.jsxgraph
+         (sci/copy-ns demo.jsxgraph (sci/create-ns 'demo.jsxgraph))}
         :classes {'Math js/Math}
         :aliases {'mb 'demo.mathbox
                   'mathbox-react "mathbox-react"

--- a/src/jsxgraph.clj
+++ b/src/jsxgraph.clj
@@ -16,13 +16,13 @@
 ;; the `mbr` forms live in [[demo.mathbox-react]] for now.
 
 (def cube-viewer
-  {:fetch-fn (fn [_ x] x)
+  {:transform-fn clerk/mark-presented
    :render-fn
    (template
-    #(do (v/html
-          [mb/Mathbox ~opts
-           [mb/Cartesian {}
-            [mb/ColorCube %]]])))})
+    #(v/html
+      [mb/Mathbox ~opts
+       [mb/Cartesian {}
+        [mb/ColorCube %]]]))})
 
 ;; We can then use the above viewer using metadata:
 
@@ -31,3 +31,29 @@
 {:dimensions [8 5 20]
  :size 20
  :opacity 1.0}
+
+(def jsx-viewer
+  {:transform-fn clerk/mark-presented
+   :render-fn
+   (template
+    (fn [value]
+      (v/html
+       (reagent/with-let [!id (reagent/atom
+                               (-> (Math/random)
+                                   (.toString 36)
+                                   (.substr 2 9)))]
+         (when value
+           [:div {:id @!id
+                  :style {:height "400px" :width "100%"}
+                  :ref
+                  ;; this is failing since jsxgraph is busted. See
+                  ;; https://github.com/jsxgraph/jsxgraph/pull/456. For now, on
+                  ;; to Mathlive!
+                  (fn [el]
+                    (when el
+                      (jsx/create @!id)))}])))))})
+
+;; We can then use the above viewer using metadata:
+^{::clerk/width :wide
+  ::clerk/viewer jsx-viewer}
+{}

--- a/src/jsxgraph.clj
+++ b/src/jsxgraph.clj
@@ -3,34 +3,9 @@
   (:require [nextjournal.clerk :as clerk]
             [pattern.rule :refer [template]]))
 
-;; ### Cube Viewer
-;;
-;; default options:
-(def opts
-  {:style {:height "400px" :width "100%"}
-   :init {:background-color 0xeeeeee
-          :max-distance 4
-          :camera-position [2.5 1 2.5]
-          :scale 720 :focus 1}})
+;; ## JSXGraph
 
-;; the `mbr` forms live in [[demo.mathbox-react]] for now.
-
-(def cube-viewer
-  {:transform-fn clerk/mark-presented
-   :render-fn
-   (template
-    #(v/html
-      [mb/Mathbox ~opts
-       [mb/Cartesian {}
-        [mb/ColorCube %]]]))})
-
-;; We can then use the above viewer using metadata:
-
-^{::clerk/width :wide
-  ::clerk/viewer cube-viewer}
-{:dimensions [8 5 20]
- :size 20
- :opacity 1.0}
+;; Here is an example viewer for JSXGraph, no configuration allowed so far:
 
 (def jsx-viewer
   {:transform-fn clerk/mark-presented
@@ -45,13 +20,9 @@
          (when value
            [:div {:id @!id
                   :style {:height "400px" :width "100%"}
-                  :ref
-                  ;; this is failing since jsxgraph is busted. See
-                  ;; https://github.com/jsxgraph/jsxgraph/pull/456. For now, on
-                  ;; to Mathlive!
-                  (fn [el]
-                    (when el
-                      (jsx/create @!id)))}])))))})
+                  :ref (fn [el]
+                         (when el
+                           (jsx/create @!id)))}])))))})
 
 ;; We can then use the above viewer using metadata:
 ^{::clerk/width :wide


### PR DESCRIPTION
This PR:

- adds a JSXGraph example and a viewer namespace (after a bunch of work in JSXGraph proper!)
- tidies up `deps.edn` to allow for local development without having to comment anything out in that file.